### PR TITLE
Fix uwsgi config.sls dicts

### DIFF
--- a/uwsgi/config.sls
+++ b/uwsgi/config.sls
@@ -30,7 +30,7 @@
    }
 %}
 {% if not emperor_config %}
-{% do app_config_defaults.update({'master': 'true'}) %}
+{% do app_config_defaults['uwsgi'].update({'master': 'true'}) %}
 {% endif %}
 
 include:
@@ -56,7 +56,14 @@ write_additional_configs_for_emperor:
 #}
 {% for app_name, app_config_overrides in salt.pillar.get('uwsgi:apps', {}).items() %}
 {% set app_config = app_config_defaults.copy() %}
-{% do app_config['uwsgi'].update(app_config_overrides['uwsgi']) %}
+{% do app_config['uwsgi'].update(app_config_overrides.get('uwsgi', {})) %}
+{% set keys = app_config_overrides.keys() %}
+{% for key in keys %}
+{% if key != 'uwsgi' %}
+{% do app_config.update([(key, app_config_overrides[key])]) %}
+{% endif %}
+{% endfor %}
+
 manage_config_for_{{ app_name }}:
   file.managed:
     - name: /etc/uwsgi/vassals/{{ app_name }}.ini

--- a/uwsgi/config.sls
+++ b/uwsgi/config.sls
@@ -6,25 +6,27 @@
    https://www.techatbloomberg.com/blog/configuring-uwsgi-production-deployment/
 #}
 {% set app_config_defaults = {
-       'strict': 'true',
-       'enable-threads': 'true',
-       'vacuum': 'true',
-       'single-interpreter': 'true',
-       'die-on-term': 'true',
-       'need-app': 'true',
-       'disable-logging': 'true',
-       'log-4xx': 'true',
-       'log-5xx': 'true',
-       'max-requests': '1000',
-       'max-worker-lifetime': '3600',
-       'processes': '2',
-       'reload-on-rss': '200',
-       'worker-reload-mercy': '60',
-       'harakiri': '60',
-       'py-callos-afterfork': 'true',
-       'buffer-size': '65535',
-       'post-buffering': '65535',
-       'auto-procname': 'true'
+       'uwsgi': {
+           'strict': 'true',
+           'enable-threads': 'true',
+           'vacuum': 'true',
+           'single-interpreter': 'true',
+           'die-on-term': 'true',
+           'need-app': 'true',
+           'disable-logging': 'true',
+           'log-4xx': 'true',
+           'log-5xx': 'true',
+           'max-requests': '1000',
+           'max-worker-lifetime': '3600',
+           'processes': '2',
+           'reload-on-rss': '200',
+           'worker-reload-mercy': '60',
+           'harakiri': '60',
+           'py-callos-afterfork': 'true',
+           'buffer-size': '65535',
+           'post-buffering': '65535',
+           'auto-procname': 'true'
+       }
    }
 %}
 {% if not emperor_config %}
@@ -54,7 +56,7 @@ write_additional_configs_for_emperor:
 #}
 {% for app_name, app_config_overrides in salt.pillar.get('uwsgi:apps', {}).items() %}
 {% set app_config = app_config_defaults.copy() %}
-{% do app_config.update(app_config_overrides) %}
+{% do app_config['uwsgi'].update(app_config_overrides['uwsgi']) %}
 manage_config_for_{{ app_name }}:
   file.managed:
     - name: /etc/uwsgi/vassals/{{ app_name }}.ini


### PR DESCRIPTION
This PR attempts to fix how defaults are overridden from pillar data. Please see commit messages.

I realized after making an earlier fix that we should allow for `.ini` file sections in addition to `[uwsgi]`. The file is allowed to have arbitrary additional sections for different apps. All we will do is provide defaults for the `uwsgi` section of the file.

I've tested this in the Python REPL as follows:

```
>>> import jinja2
>>> jinja_env = Environment(extensions=['jinja2.ext.do'])
>>> txt = """
... {% set app_config_defaults = {
...        'uwsgi': {
...            'strict': 'true',
...            'enable-threads': 'true',
...            'vacuum': 'true',
...            'single-interpreter': 'true',
...            'die-on-term': 'true',
...            'need-app': 'true',
...            'disable-logging': 'true',
...            'log-4xx': 'true',
...            'log-5xx': 'true',
...            'max-requests': '1000',
...            'max-worker-lifetime': '3600',
...            'processes': '2',
...            'reload-on-rss': '200',
...            'worker-reload-mercy': '60',
...            'harakiri': '60',
...            'py-callos-afterfork': 'true',
...            'buffer-size': '65535',
...            'post-buffering': '65535',
...            'auto-procname': 'true'
...        }
...    }
... %}
... {% do app_config_defaults['uwsgi'].update({'master': 'true'}) %}
...
... {% set app_config_overrides = {
...        'uwsgi': {
...            'foo': 'x'
...        },
...        'a': {
...            'aa': 'aaa'
...        }
... }
... %}
...
... {% set app_config = app_config_defaults.copy() %}
... {% do app_config['uwsgi'].update(app_config_overrides.get('uwsgi', {})) %}
...
... {% set keys = app_config_overrides.keys() %}
...
... {% for key in keys %}
... {% if key != 'uwsgi' %}
... {% do app_config.update([(key, app_config_overrides[key])]) %}
... {% endif %}
... {% endfor %}
...
... {{ app_config | tojson }}
... """
>>>
>>> t = jinja_env.from_string(txt)
>>> print(t.render())

{"a": {"aa": "aaa"}, "uwsgi": {"auto-procname": "true", "buffer-size": "65535", "die-on-term": "true", "disable-logging": "true", "enable-threads": "true", "foo": "x", "harakiri": "60", "log-4xx": "true", "log-5xx": "true", "master": "true", "max-requests": "1000", "max-worker-lifetime": "3600", "need-app": "true", "post-buffering": "65535", "processes": "2", "py-callos-afterfork": "true", "reload-on-rss": "200", "single-interpreter": "true", "strict": "true", "vacuum": "true", "worker-reload-mercy": "60"}}
```

For your convenience, here is the Python code formatted suitably for pasting into your interpreter:
```
txt = """
{% set app_config_defaults = {
       'uwsgi': {
           'strict': 'true',
           'enable-threads': 'true',
           'vacuum': 'true',
           'single-interpreter': 'true',
           'die-on-term': 'true',
           'need-app': 'true',
           'disable-logging': 'true',
           'log-4xx': 'true',
           'log-5xx': 'true',
           'max-requests': '1000',
           'max-worker-lifetime': '3600',
           'processes': '2',
           'reload-on-rss': '200',
           'worker-reload-mercy': '60',
           'harakiri': '60',
           'py-callos-afterfork': 'true',
           'buffer-size': '65535',
           'post-buffering': '65535',
           'auto-procname': 'true'
       }
   }
%}
{% do app_config_defaults['uwsgi'].update({'master': 'true'}) %}

{% set app_config_overrides = {
       'uwsgi': {
           'foo': 'x'
       },
       'a': {
           'aa': 'aaa'
       }
}
%}

{% set app_config = app_config_defaults.copy() %}
{% do app_config['uwsgi'].update(app_config_overrides.get('uwsgi', {})) %}

{% set keys = app_config_overrides.keys() %}

{% for key in keys %}
{% if key != 'uwsgi' %}
{% do app_config.update([(key, app_config_overrides[key])]) %}
{% endif %}
{% endfor %}

{{ app_config | tojson }}
"""

t = jinja_env.from_string(txt)
print(t.render())
```
